### PR TITLE
Addressed feedback for app-only and delegated permissions and grants

### DIFF
--- a/api-reference/beta/api/group-delete-approleassignments.md
+++ b/api-reference/beta/api/group-delete-approleassignments.md
@@ -1,6 +1,6 @@
 ---
 title: "Delete an appRoleAssignment from a group"
-description: "Delete an appRoleAssignment from a group."
+description: "Delete an appRoleAssignment that has been granted to a group."
 localization_priority: Normal
 doc_type: apiPageType
 ms.prod: "microsoft-identity-platform"
@@ -11,7 +11,7 @@ author: "davidmu1"
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-Deletes an [appRoleAssignment](../resources/approleassignment.md) which a group has been granted.
+Deletes an [appRoleAssignment](../resources/approleassignment.md) that a group has been granted.
 
 ## Permissions
 
@@ -32,7 +32,7 @@ DELETE /groups/{id}/appRoleAssignments/{id}
 ```
 
 > [!NOTE]
-> As a best practice, we recommend deleting app role assignments through the `appRoleAssignedTo` relationship of the _resource_ service principal, instead of the `appRoleAssignments` relationship of the assigned user, group or service principal.
+> As a best practice, we recommend deleting app role assignments through the `appRoleAssignedTo` relationship of the _resource_ service principal, instead of the `appRoleAssignments` relationship of the assigned user, group, or service principal.
 
 ## Request headers
 

--- a/api-reference/beta/api/group-list-approleassignments.md
+++ b/api-reference/beta/api/group-list-approleassignments.md
@@ -1,6 +1,6 @@
 ---
 title: "List appRoleAssignments granted to a group"
-description: "Retrieve the list of app role assignments granted to a group."
+description: "Retrieve the list of appRoleAssignments that have been granted to a group."
 localization_priority: Priority
 doc_type: apiPageType
 ms.prod: "microsoft-identity-platform"
@@ -11,7 +11,7 @@ author: "davidmu1"
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-Retrieve the list of [appRoleAssignment](../resources/approleassignment.md) which a group has been granted.
+Retrieve the list of [appRoleAssignment](../resources/approleassignment.md) that a group has been granted.
 
 ## Permissions
 
@@ -32,7 +32,7 @@ GET /groups/{id}/appRoleAssignments
 
 ## Optional query parameters
 
-This method supports the [OData Query Parameters](https://developer.microsoft.com/graph/docs/concepts/query_parameters) to help customize the response.
+This method supports the [OData query parameters](/graph/query_parameters) to help customize the response.
 
 See [supported filter patterns](../resources/approleassignment.md#supported-filter-patterns) to learn how to search for and filter app role assignments.
 
@@ -67,7 +67,9 @@ GET https://graph.microsoft.com/beta/groups/{id}/appRoleAssignments
 
 ### Response
 
-Here is an example of the response. Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.
+Here is an example of the response.
+
+> **Note:** The response object shown here might be shortened for readability. All the properties will be returned from an actual call.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/oauth2permissiongrant-delete.md
+++ b/api-reference/beta/api/oauth2permissiongrant-delete.md
@@ -1,5 +1,5 @@
 ---
-title: "Delete a delegated permission grant (oAuth2PermissionGrant)"
+title: "Delete an oAuth2PermissionGrant"
 description: "Delete an oAuth2PermissionGrant, representing a delegated permission grant."
 localization_priority: Normal
 doc_type: apiPageType

--- a/api-reference/beta/api/oauth2permissiongrant-get.md
+++ b/api-reference/beta/api/oauth2permissiongrant-get.md
@@ -1,6 +1,6 @@
 ---
-title: "Get a delegated permission grant (oAuth2PermissionGrant)"
-description: "Retrieve the properties and relationships of single oAuth2PermissionGrant object."
+title: "Get an oAuth2PermissionGrant"
+description: "Retrieve the properties and relationships of single oAuth2PermissionGrant, representing a delegated permission grant."
 localization_priority: Normal
 doc_type: apiPageType
 ms.prod: "microsoft-identity-platform"
@@ -35,7 +35,7 @@ GET /oauth2PermissionGrants/{id}
 
 ## Optional query parameters
 
-This method supports the [OData Query Parameters](https://developer.microsoft.com/graph/docs/concepts/query_parameters) to help customize the response.
+This method supports the [OData query parameters](/graph/query_parameters) to help customize the response.
 
 ## Request headers
 
@@ -83,7 +83,9 @@ GET https://graph.microsoft.com/beta/oauth2PermissionGrants/{id}
 
 ### Response
 
-Here is an example of the response. Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.
+Here is an example of the response. 
+
+> **Note:** The response object shown here might be shortened for readability. All the properties will be returned from an actual call.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/oauth2permissiongrant-list.md
+++ b/api-reference/beta/api/oauth2permissiongrant-list.md
@@ -1,6 +1,6 @@
 ---
-title: "List delegated permission grants (list oauth2PermissionGrants)"
-description: "Retrieve a list of oauth2PermissionGrant objects."
+title: "List oAuth2PermissionGrants"
+description: "Retrieve a list of oauth2PermissionGrant objects, representing delegated permission grants."
 localization_priority: Normal
 doc_type: apiPageType
 ms.prod: "microsoft-identity-platform"
@@ -33,7 +33,7 @@ GET /oauth2PermissionGrants
 
 ## Optional query parameters
 
-This method supports the [OData Query Parameters](https://developer.microsoft.com/graph/docs/concepts/query_parameters) to help customize the response.
+This method supports the [OData query parameters](/graph/query_parameters) to help customize the response.
 
 ## Request headers
 
@@ -66,7 +66,7 @@ GET https://graph.microsoft.com/beta/oauth2PermissionGrants
 
 ### Response
 
-Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.
+> **Note:** The response object shown here might be shortened for readability. All the properties will be returned from an actual call.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/oauth2permissiongrant-post.md
+++ b/api-reference/beta/api/oauth2permissiongrant-post.md
@@ -1,5 +1,5 @@
 ---
-title: "Create a delegated permission grant (oAuth2PermissionGrant)"
+title: "Create an oAuth2PermissionGrant"
 description: "Create an oAuth2PermissionGrant object, representing a delegated permission grant."
 localization_priority: Normal
 doc_type: apiPageType
@@ -64,7 +64,6 @@ Content-Type: application/json
 Content-Length: 30
 
 {
-  "id": "id-value",
   "clientId": "clientId-value",
   "consentType": "consentType-value",
   "principalId": "principalId-value",

--- a/api-reference/beta/api/oauth2permissiongrant-update.md
+++ b/api-reference/beta/api/oauth2permissiongrant-update.md
@@ -1,6 +1,6 @@
 ---
-title: "Update a delegated permission grant (oAuth2PermissionGrant)"
-description: "Update the properties of an oAuth2PermissionGrant object representing a delegated permission grant."
+title: "Update an oAuth2PermissionGrant"
+description: "Update the properties of an oAuth2PermissionGrant, representing a delegated permission grant."
 localization_priority: Normal
 doc_type: apiPageType
 ms.prod: "microsoft-identity-platform"

--- a/api-reference/beta/api/serviceprincipal-delete-approleassignedto.md
+++ b/api-reference/beta/api/serviceprincipal-delete-approleassignedto.md
@@ -11,7 +11,7 @@ author: "davidmu1"
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-Deletes an [appRoleAssignment](../resources/approleassignment.md) which a user, group or client service principal has been granted for a resource service principal.
+Deletes an [appRoleAssignment](../resources/approleassignment.md) that a user, group, or client service principal has been granted for a resource service principal.
 
 ## Permissions
 
@@ -32,7 +32,7 @@ DELETE /servicePrincipals/{id}/appRoleAssignedTo/{id}
 ```
 
 > [!NOTE]
-> As a best practice, we recommend deleting app role assignments through the `appRoleAssignedTo` relationship of the _resource_ service principal, instead of the `appRoleAssignments` relationship of the assigned user, group or service principal.
+> As a best practice, we recommend deleting app role assignments through the `appRoleAssignedTo` relationship of the _resource_ service principal, instead of the `appRoleAssignments` relationship of the assigned user, group, or service principal.
 
 ## Request headers
 

--- a/api-reference/beta/api/serviceprincipal-delete-approleassignments.md
+++ b/api-reference/beta/api/serviceprincipal-delete-approleassignments.md
@@ -11,7 +11,7 @@ author: "davidmu1"
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-Deletes an [appRoleAssignment](../resources/approleassignment.md) which a service principal has been granted.
+Deletes an [appRoleAssignment](../resources/approleassignment.md) that a service principal has been granted.
 
 App roles which are assigned to service principals are also known as [application permissions](https://docs.microsoft.com/azure/active-directory/develop/v2-permissions-and-consent#permission-types). Deleting an app role assignment for a service principal is equivalent to revoking the app-only permission grant.
 
@@ -34,7 +34,7 @@ DELETE /servicePrincipals/{id}/appRoleAssignments/{id}
 ```
 
 > [!NOTE]
-> As a best practice, we recommend deleting app role assignments through the `appRoleAssignedTo` relationship of the _resource_ service principal, instead of the `appRoleAssignments` relationship of the assigned user, group or service principal.
+> As a best practice, we recommend deleting app role assignments through the `appRoleAssignedTo` relationship of the _resource_ service principal, instead of the `appRoleAssignments` relationship of the assigned user, group, or service principal.
 
 ## Request headers
 

--- a/api-reference/beta/api/serviceprincipal-list-oauth2permissiongrants.md
+++ b/api-reference/beta/api/serviceprincipal-list-oauth2permissiongrants.md
@@ -2,7 +2,7 @@
 title: "servicePrincipal: List delegated permission grants (oauth2PermissionGrants)"
 description: "Retrieve a list of oAuth2PermissionGrant objects, representing delegated permission grants."
 localization_priority: Priority
-doc_type: resourcePageType
+doc_type: apiPageType
 ms.prod: "microsoft-identity-platform"
 author: "davidmu1"
 ---
@@ -33,7 +33,7 @@ GET /servicePrincipals/{id}/oauth2PermissionGrants
 
 ## Optional query parameters
 
-This method supports the [OData Query Parameters](https://developer.microsoft.com/graph/docs/concepts/query_parameters) to help customize the response.
+This method supports the [OData query parameters](/graph/query_parameters) to help customize the response.
 
 ## Request headers
 
@@ -66,7 +66,9 @@ GET https://graph.microsoft.com/beta/servicePrincipals/{id}/oauth2PermissionGran
 
 ### Response
 
-Here is an example of the response. Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.
+Here is an example of the response. 
+
+> **Note:** The response object shown here might be shortened for readability. All the properties will be returned from an actual call.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/serviceprincipal-post-approleassignedto.md
+++ b/api-reference/beta/api/serviceprincipal-post-approleassignedto.md
@@ -76,7 +76,7 @@ Content-Length: 110
 }
 ```
 
-In this example, `{id}` and `{resourceId-value}` would both be the `id` of the resource service principal, and `{principalId}` would be the `id` of the assigned user, group or client service principal.
+In this example, `{id}` and `{resourceId-value}` would both be the `id` of the resource service principal, and `{principalId}` would be the `id` of the assigned user, group, or client service principal.
 
 ### Response
 

--- a/api-reference/beta/api/user-delete-approleassignments.md
+++ b/api-reference/beta/api/user-delete-approleassignments.md
@@ -32,7 +32,7 @@ DELETE /users/{id}/appRoleAssignments/{id}
 ```
 
 > [!NOTE]
-> As a best practice, we recommend deleting app role assignments through the `appRoleAssignedTo` relationship of the _resource_ service principal, instead of the `appRoleAssignments` relationship of the assigned user, group or service principal.
+> As a best practice, we recommend deleting app role assignments through the `appRoleAssignedTo` relationship of the _resource_ service principal, instead of the `appRoleAssignments` relationship of the assigned user, group, or service principal.
 
 ## Request headers
 

--- a/api-reference/beta/api/user-list-approleassignments.md
+++ b/api-reference/beta/api/user-list-approleassignments.md
@@ -11,7 +11,7 @@ author: "davidmu1"
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-Retrieve the list of [appRoleAssignment](../resources/approleassignment.md) which a user has been granted. Also returns app roles assigned to groups which the user is a direct member of.
+Retrieve the list of [appRoleAssignment](../resources/approleassignment.md) that a user has been granted. Also returns app roles assigned to groups that the user is a direct member of.
 
 ## Permissions
 
@@ -32,7 +32,7 @@ GET /users/{id | userPrincipalName}/appRoleAssignments
 
 ## Optional query parameters
 
-This method supports the [OData Query Parameters](https://developer.microsoft.com/graph/docs/concepts/query_parameters) to help customize the response.
+This method supports the [OData query parameters](/graph/query_parameters) to help customize the response.
 
 See [supported filter patterns](../resources/approleassignment.md#supported-filter-patterns) to learn how to search for and filter app role assignments.
 
@@ -67,7 +67,9 @@ GET https://graph.microsoft.com/beta/users/{id}/appRoleAssignments
 
 ### Response
 
-Here is an example of the response. Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.
+Here is an example of the response. 
+
+> **Note:** The response object shown here might be shortened for readability. All the properties will be returned from an actual call.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/user-list-oauth2permissiongrants.md
+++ b/api-reference/beta/api/user-list-oauth2permissiongrants.md
@@ -2,7 +2,7 @@
 title: "user: List delegated permission grants (oauth2PermissionGrants)"
 description: "Retrieve a list of oAuth2PermissionGrant objects, representing delegated permission grants."
 localization_priority: Priority
-doc_type: resourcePageType
+doc_type: apiPageType
 ms.prod: "microsoft-identity-platform"
 author: "davidmu1"
 ---
@@ -37,7 +37,7 @@ GET /users/{id | userPrincipalName}/oauth2PermissionGrants
 
 ## Optional query parameters
 
-This method supports the [OData Query Parameters](https://developer.microsoft.com/graph/docs/concepts/query_parameters) to help customize the response.
+This method supports the [OData query parameters](/graph/query_parameters) to help customize the response.
 
 ## Request headers
 
@@ -70,7 +70,9 @@ GET https://graph.microsoft.com/beta/users/{id}/oauth2PermissionGrants
 
 ### Response
 
-Here is an example of the response. Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.
+Here is an example of the response. 
+
+> **Note:** The response object shown here might be shortened for readability. All the properties will be returned from an actual call.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/user-post-approleassignments.md
+++ b/api-reference/beta/api/user-post-approleassignments.md
@@ -35,7 +35,7 @@ POST /users/{id | userPrincipalName}/appRoleAssignments
 ```
 
 > [!NOTE]
-> As a best practice, we recommend creating app role assignments through the `appRoleAssignedTo` relationship of the _resource_ service principal, instead of the `appRoleAssignments` relationship of the assigned user, group or service principal.
+> As a best practice, we recommend creating app role assignments through the `appRoleAssignedTo` relationship of the _resource_ service principal, instead of the `appRoleAssignments` relationship of the assigned user, group, or service principal.
 
 ## Request headers
 
@@ -79,7 +79,9 @@ In this example, `{id}` and `{principalId-value}` would both be the `id` of the 
 
 ### Response
 
-Here is an example of the response. Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.
+Here is an example of the response. 
+
+> **Note:** The response object shown here might be shortened for readability. All the properties will be returned from an actual call.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/resources/approleassignment.md
+++ b/api-reference/beta/resources/approleassignment.md
@@ -1,17 +1,17 @@
 ---
 title: "appRoleAssignment resource type"
-description: "Used to record when a user, group or service principal is assigned to an app role on an application's service principal. You can create, read and delete app role assignments."
+description: "Used to record when a user, group, or service principal is assigned to an app role on an application's service principal. You can create, read and delete app role assignments."
 localization_priority: Priority
 doc_type: resourcePageType
 ms.prod: "microsoft-identity-platform"
-author: "psignoret"
+author: "davidmu1"
 ---
 
 # appRoleAssignment resource type
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-Used to record when a user, group or service principal is assigned an app role for an app.
+Used to record when a user, group, or service principal is assigned an app role for an app.
 
 An app role assignment is a relationship between the assigned principal (a user, a group, or a service principal), a resource application (the app's service principal) and an app role defined on the resource application.
 
@@ -29,7 +29,7 @@ An app role assignment where the assigned principal is a service principal is an
 | creationTimestamp | DateTimeOffset | The time when the app role assignment was created.The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: `'2014-01-01T00:00:00Z'`. Read-only. Does not support `$filter`. |
 | principalId | Guid | The unique identifier (**id**) for the [user](user.md), [group](group.md) or [service principal](serviceprincipal.md) being granted the app role. Required on create. Does not support `$filter` (see [note](#unsupported-filter-patterns)). |
 | principalType | String | The type of the assigned principal. This can either be "User", "Group" or "ServicePrincipal". Read-only. Does not support `$filter`. |
-| principalDisplayName | String |The display name of the user, group or service principal that was granted the app role assignment. Read-only. Supports `$filter` (`eq` and `startswith`). |
+| principalDisplayName | String |The display name of the user, group, or service principal that was granted the app role assignment. Read-only. Supports `$filter` (`eq` and `startswith`). |
 | resourceId | Guid |The unique identifier (**id**) for the resource [service principal](serviceprincipal.md) for which the assignment is made. Required on create. Supports `$filter` (`eq` only). |
 | resourceDisplayName | String | The display name of the resource app's service principal to which the assignment is made. Does not support `$filter`. |
 | appRoleId | Guid | The identifier (**id**) for the [app role](approle.md) which is assigned to the principal. This app role must be exposed in the **appRoles** property on the resource application's service principal (**resourceId**). If the resource application has not declared any app roles, a default app role ID of `00000000-0000-0000-0000-000000000000` can be specified to signal that the principal is assigned to the resource app without any specific app roles. Required on create. Does not support `$filter`. |
@@ -63,9 +63,9 @@ Here is a JSON representation of the resource
 
 Below are some common query patterns for app role assignments.
 
-### List the app role assignments a user, group or service principal has been granted for an app
+### List the app role assignments a user, group, or service principal has been granted for an app
 
-To find the app role assignments granted to a user, group or service principal (`{principal-id}`), for a given resource app (`{resource-id}`), query the `appRoleAssignments` navigation of the assigned principal and filter by `resourceId`.
+To find the app role assignments granted to a user, group, or service principal (`{principal-id}`), for a given resource app (`{resource-id}`), query the `appRoleAssignments` navigation of the assigned principal and filter by `resourceId`.
 
 ```http
 GET https://graph.microsoft.com/beta/users/{principal-id}/appRoleAssignments
@@ -84,7 +84,7 @@ GET https://graph.microsoft.com/beta/servicePrincipals/{principal-id}/appRoleAss
 
 ### Search for assigned principal by display name
 
-To find the app role assignments granted for an app (`{resource-id}`) and filter by the assigned users, groups and service principals' display name, query the `appRoleAssignedTo` navigation of the resource app's service principal and filter by `principalDisplayName`.
+To find the app role assignments granted for an app (`{resource-id}`) and filter by the assigned users, groups, and service principals' display name, query the `appRoleAssignedTo` navigation of the resource app's service principal and filter by `principalDisplayName`.
 
 ```http
 GET https://graph.microsoft.com/beta/servicePrincipals/{resource-id}/appRoleAssignedTo
@@ -100,7 +100,7 @@ GET https://graph.microsoft.com/beta/servicePrincipals/{resource-id}/appRoleAssi
 
 The following are some examples scenarios where service-side filtering is not currently supported, and client-side filtering may be required:
 
-* Filtering by `resourceDisplayName` for a given user, group or service principal is not supported. Instead, retrieve all app role assignments granted to assigned principal (with the `appRoleAssignments` navigation) and filter the results on the client side. Alternatively, filter all [**servicePrincipals**](../resources/serviceprincipal.md) to find the resource app's service principal `id`, and then filter the assigned principal's `appRoleAssignments` by `resourceId`. 
+* Filtering by `resourceDisplayName` for a given user, group, or service principal is not supported. Instead, retrieve all app role assignments granted to assigned principal (with the `appRoleAssignments` navigation) and filter the results on the client side. Alternatively, filter all [**servicePrincipals**](../resources/serviceprincipal.md) to find the resource app's service principal `id`, and then filter the assigned principal's `appRoleAssignments` by `resourceId`. 
 * Filtering by `appRoleId` is not supported. Instead, retrieve all app role assignments for the assigned principal and resource app (`appRoleAssignments` filtered by `resourceId`), or all app role assignments for the resource app (`appRoleAssignedTo`), and then further filter the results on the client side.
 * Filtering by `principalId` is not supported, but is usually not needed. Instead, query the assigned principal's app role assignments and filter by `resourceId`.
 

--- a/api-reference/beta/resources/educationsynchronizationoauth1connectionsettings.md
+++ b/api-reference/beta/resources/educationsynchronizationoauth1connectionsettings.md
@@ -4,7 +4,7 @@ description: "When OAuth1 is to be used to connect to the data provider, this co
 localization_priority: Normal
 author: "mmast-msft"
 ms.prod: "education"
-doc_type: resourcePageType
+doc_type: apiPageType
 ---
 
 # educationSynchronizationOAuth1ConnectionSettings resource

--- a/api-reference/beta/resources/educationsynchronizationoauth2clientcredentialsconnectionsettings.md
+++ b/api-reference/beta/resources/educationsynchronizationoauth2clientcredentialsconnectionsettings.md
@@ -4,7 +4,7 @@ description: "When OAuth2 Client Credentials Grant is to be used to connect to t
 localization_priority: Normal
 author: "mmast-msft"
 ms.prod: "education"
-doc_type: resourcePageType
+doc_type: apiPageType
 ---
 
 # educationSynchronizationOAuth2ClientCredentialsConnectionSettings resource

--- a/api-reference/beta/resources/serviceprincipal.md
+++ b/api-reference/beta/resources/serviceprincipal.md
@@ -31,9 +31,9 @@ This resource supports using [delta query](/graph/delta-query-overview) to track
 |[List appRoleAssignments](../api/serviceprincipal-list-approleassignments.md) |[appRoleAssignment](approleassignment.md) collection| Get the app roles which this service principal has been assigned.|
 |[Add appRoleAssignment](../api/serviceprincipal-post-approleassignments.md) |[appRoleAssignment](approleassignment.md)| Assign an app role to this service principal.|
 |[Remove appRoleAssignment](../api/serviceprincipal-delete-approleassignments.md) | None | Remove an app role assignment from this service principal.|
-|[List appRoleAssignedTo](../api/serviceprincipal-list-approleassignedto.md) |[appRoleAssignment](approleassignment.md) collection| Get the users, groups and service principals assigned app roles for this service principal.|
-|[Add appRoleAssignedTo](../api/serviceprincipal-post-approleassignedto.md) |[appRoleAssignment](approleassignment.md)| Assign an app role for this service principal to a user, group or service principal.|
-|[Remove appRoleAssignedTo](../api/serviceprincipal-delete-approleassignedto.md) | None | Remove an app role assignment for this service principal from a user, group or service principal.|
+|[List appRoleAssignedTo](../api/serviceprincipal-list-approleassignedto.md) |[appRoleAssignment](approleassignment.md) collection| Get the users, groups, and service principals assigned app roles for this service principal.|
+|[Add appRoleAssignedTo](../api/serviceprincipal-post-approleassignedto.md) |[appRoleAssignment](approleassignment.md)| Assign an app role for this service principal to a user, group, or service principal.|
+|[Remove appRoleAssignedTo](../api/serviceprincipal-delete-approleassignedto.md) | None | Remove an app role assignment for this service principal from a user, group, or service principal.|
 |**Certificates & secrets**| | |
 |[Add password](../api/serviceprincipal-addpassword.md)|[passwordCredential](passwordcredential.md)|Add a strong password to a servicePrincipal.|
 |[Remove password](../api/serviceprincipal-removepassword.md)|[passwordCredential](passwordcredential.md)|Remove a password from a servicePrincipal.|

--- a/api-reference/v1.0/api/group-delete-approleassignments.md
+++ b/api-reference/v1.0/api/group-delete-approleassignments.md
@@ -1,6 +1,6 @@
 ---
 title: "Delete an appRoleAssignment from a group"
-description: "Delete an appRoleAssignment from a group."
+description: "Delete an appRoleAssignment that has been granted to a group."
 localization_priority: Normal
 doc_type: apiPageType
 ms.prod: "microsoft-identity-platform"
@@ -30,7 +30,7 @@ DELETE /groups/{id}/appRoleAssignments/{id}
 ```
 
 > [!NOTE]
-> As a best practice, we recommend deleting app role assignments through the `appRoleAssignedTo` relationship of the _resource_ service principal, instead of the `appRoleAssignments` relationship of the assigned user, group or service principal.
+> As a best practice, we recommend deleting app role assignments through the `appRoleAssignedTo` relationship of the _resource_ service principal, instead of the `appRoleAssignments` relationship of the assigned user, group, or service principal.
 
 ## Request headers
 

--- a/api-reference/v1.0/api/group-list-approleassignments.md
+++ b/api-reference/v1.0/api/group-list-approleassignments.md
@@ -1,6 +1,6 @@
 ---
 title: "List appRoleAssignments granted to a group"
-description: "Retrieve the list of app role assignments granted to a group."
+description: "Retrieve the list of appRoleAssignments that have been granted to a group."
 localization_priority: Priority
 doc_type: apiPageType
 ms.prod: "microsoft-identity-platform"
@@ -30,7 +30,7 @@ GET /groups/{id}/appRoleAssignments
 
 ## Optional query parameters
 
-This method supports the [OData Query Parameters](https://developer.microsoft.com/graph/docs/concepts/query_parameters) to help customize the response.
+This method supports the [OData query parameters](/graph/query_parameters) to help customize the response.
 
 See [supported filter patterns](../resources/approleassignment.md#supported-filter-patterns) to learn how to search for and filter app role assignments.
 
@@ -65,7 +65,9 @@ GET https://graph.microsoft.com/v1.0/groups/{id}/appRoleAssignments
 
 ### Response
 
-Here is an example of the response. Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.
+Here is an example of the response.
+
+> **Note:** The response object shown here might be shortened for readability. All the properties will be returned from an actual call.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/group-post-approleassignments.md
+++ b/api-reference/v1.0/api/group-post-approleassignments.md
@@ -11,11 +11,11 @@ author: "davidmu1"
 
 Use this API to assign an app role to a group. All direct members of the group will be considered assigned. To grant an app role assignment to a group, you need three identifiers:
 
-1. `principalId`: The `id` of the group to which you are assigning the app role.
-2. `resourceId`: The `id` of the resource `servicePrincipal` which has defined the app role.
-3. `appRoleId`: The `id` of the `appRole` (defined on the resource service principal) to assign to the group.
+- `principalId`: The `id` of the group to which you are assigning the app role.
+- `resourceId`: The `id` of the resource `servicePrincipal` which has defined the app role.
+- `appRoleId`: The `id` of the `appRole` (defined on the resource service principal) to assign to the group.
 
-Additional licenses may be required to [use a group to manage access to applications](https://docs.microsoft.com/azure/active-directory/users-groups-roles/groups-saasapps).
+Additional licenses might be required to [use a group to manage access to applications](https://docs.microsoft.com/azure/active-directory/users-groups-roles/groups-saasapps).
 
 ## Permissions
 
@@ -23,9 +23,9 @@ One of the following permissions is required to call this API. To learn more, in
 
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
-|Delegated (work or school account) | AppRoleAssignment.ReadWrite.All,Directory.AccessAsUser.All    |
+|Delegated (work or school account) | AppRoleAssignment.ReadWrite.All, Directory.AccessAsUser.All    |
 |Delegated (personal Microsoft account) | Not supported.    |
-|Application | AppRoleAssignment.ReadWrite.All, |
+|Application | AppRoleAssignment.ReadWrite.All |
 
 ## HTTP request
 
@@ -35,7 +35,7 @@ POST /groups/{id}/appRoleAssignments
 ```
 
 > [!NOTE]
-> As a best practice, we recommend creating app role assignments through the `appRoleAssignedTo` relationship of the _resource_ service principal, instead of the `appRoleAssignments` relationship of the assigned user, group or service principal.
+> As a best practice, we recommend creating app role assignments through the `appRoleAssignedTo` relationship of the _resource_ service principal, instead of the `appRoleAssignments` relationship of the assigned user, group, or service principal.
 
 ## Request headers
 
@@ -46,11 +46,11 @@ POST /groups/{id}/appRoleAssignments
 
 ## Request body
 
-In the request body, supply a JSON representation of [appRoleAssignment](../resources/approleassignment.md) object.
+In the request body, supply a JSON representation of an [appRoleAssignment](../resources/approleassignment.md) object.
 
 ## Response
 
-If successful, this method returns `201 Created` response code and [appRoleAssignment](../resources/approleassignment.md) object in the response body.
+If successful, this method returns a `201 Created` response code and an [appRoleAssignment](../resources/approleassignment.md) object in the response body.
 
 ## Examples
 
@@ -79,7 +79,9 @@ In this example, `{id}` and `{principalId-value}` would both be the `id` of the 
 
 ### Response
 
-Here is an example of the response. Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.
+Here is an example of the response. 
+
+>**Note:** The response object shown here might be shortened for readability. All the properties will be returned from an actual call.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/oauth2permissiongrant-delete.md
+++ b/api-reference/v1.0/api/oauth2permissiongrant-delete.md
@@ -1,5 +1,5 @@
 ---
-title: "Delete a delegated permission grant (oAuth2PermissionGrant)"
+title: "Delete an oAuth2PermissionGrant"
 description: "Delete an oAuth2PermissionGrant, representing a delegated permission grant."
 localization_priority: Normal
 doc_type: apiPageType
@@ -29,13 +29,13 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 
 <!-- { "blockType": "ignored" } -->
+
 ```http
 DELETE /oAuth2Permissiongrants/{id}
-DELETE /users/{id | userPrincipalName}/oAuth2Permissiongrants/{id}
-DELETE /drive/root/createdByUser/oAuth2Permissiongrants/{id}
-
 ```
+
 ## Request headers
+
 | Name       | Type | Description|
 |:---------------|:--------|:----------|
 | Authorization  | string  | Bearer {token}. Required. |

--- a/api-reference/v1.0/api/oauth2permissiongrant-get.md
+++ b/api-reference/v1.0/api/oauth2permissiongrant-get.md
@@ -1,6 +1,6 @@
 ---
-title: "Get a delegated permission grant (oAuth2PermissionGrant)"
-description: "Retrieve the properties and relationships of single oAuth2PermissionGrant object."
+title: "Get an oAuth2PermissionGrant"
+description: "Retrieve the properties and relationships of single oAuth2PermissionGrant, representing a delegated permission grant."
 localization_priority: Normal
 doc_type: apiPageType
 ms.prod: "microsoft-identity-platform"
@@ -33,7 +33,7 @@ GET /oauth2PermissionGrants/{id}
 
 ## Optional query parameters
 
-This method supports the [OData Query Parameters](https://developer.microsoft.com/graph/docs/concepts/query_parameters) to help customize the response.
+This method supports the [OData query parameters](/graph/query_parameters) to help customize the response.
 
 ## Request headers
 
@@ -67,7 +67,9 @@ GET https://graph.microsoft.com/v1.0/oauth2PermissionGrants/{id}
 
 ### Response
 
-Here is an example of the response. Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.
+Here is an example of the response. 
+
+> **Note:** The response object shown here might be shortened for readability. All the properties will be returned from an actual call.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/oauth2permissiongrant-list.md
+++ b/api-reference/v1.0/api/oauth2permissiongrant-list.md
@@ -1,6 +1,6 @@
 ---
-title: "List delegated permission grants (list oauth2PermissionGrants)"
-description: "Retrieve a list of oauth2PermissionGrant objects."
+title: "List oAuth2PermissionGrants"
+description: "Retrieve a list of oauth2PermissionGrant objects, representing delegated permission grants."
 localization_priority: Normal
 doc_type: apiPageType
 ms.prod: "microsoft-identity-platform"
@@ -17,7 +17,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
-|Delegated (work or school account) | Directory.Read.All, Directory.ReadWrite.All, Directory.AccessAsUser.All    |
+|Delegated (work or school account) | Directory.Read.All, DelegatedPermissionGrant.ReadWrite.All, Directory.ReadWrite.All, Directory.AccessAsUser.All    |
 |Delegated (personal Microsoft account) | Not supported.    |
 |Application | Directory.Read.All, Directory.ReadWrite.All |
 
@@ -31,7 +31,7 @@ GET /oauth2PermissionGrants
 
 ## Optional query parameters
 
-This method supports the [OData Query Parameters](https://developer.microsoft.com/graph/docs/concepts/query_parameters) to help customize the response.
+This method supports the [OData query parameters](/graph/query_parameters) to help customize the response.
 
 ## Request headers
 
@@ -64,7 +64,7 @@ GET https://graph.microsoft.com/v1.0/oauth2PermissionGrants
 
 ### Response
 
-Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.
+> **Note:** The response object shown here might be shortened for readability. All the properties will be returned from an actual call.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/oauth2permissiongrant-post.md
+++ b/api-reference/v1.0/api/oauth2permissiongrant-post.md
@@ -1,5 +1,5 @@
 ---
-title: "Create a delegated permission grant (oAuth2PermissionGrant)"
+title: "Create an oAuth2PermissionGrant"
 description: "Create an oAuth2PermissionGrant object, representing a delegated permission grant."
 localization_priority: Normal
 doc_type: apiPageType
@@ -63,7 +63,6 @@ Content-Type: application/json
 Content-Length: 30
 
 {
-  "id": "id-value",
   "clientId": "clientId-value",
   "consentType": "consentType-value",
   "principalId": "principalId-value",

--- a/api-reference/v1.0/api/oauth2permissiongrant-update.md
+++ b/api-reference/v1.0/api/oauth2permissiongrant-update.md
@@ -1,6 +1,6 @@
 ---
-title: "Update a delegated permission grant (oAuth2PermissionGrant)"
-description: "Update the properties of an oAuth2PermissionGrant object representing a delegated permission grant."
+title: "Update an oAuth2PermissionGrant"
+description: "Update the properties of an oAuth2PermissionGrant, representing a delegated permission grant."
 localization_priority: Normal
 doc_type: apiPageType
 ms.prod: "microsoft-identity-platform"

--- a/api-reference/v1.0/api/serviceprincipal-delete-approleassignedto.md
+++ b/api-reference/v1.0/api/serviceprincipal-delete-approleassignedto.md
@@ -9,7 +9,7 @@ author: "davidmu1"
 
 # Delete an appRoleAssignment granted for a service principal
 
-Deletes an [appRoleAssignment](../resources/approleassignment.md) which a user, group or client service principal has been granted for a resource service principal.
+Deletes an [appRoleAssignment](../resources/approleassignment.md) that a user, group, or client service principal has been granted for a resource service principal.
 
 ## Permissions
 
@@ -30,7 +30,7 @@ DELETE /servicePrincipals/{id}/appRoleAssignedTo/{id}
 ```
 
 > [!NOTE]
-> As a best practice, we recommend deleting app role assignments through the `appRoleAssignedTo` relationship of the _resource_ service principal, instead of the `appRoleAssignments` relationship of the assigned user, group or service principal.
+> As a best practice, we recommend deleting app role assignments through the `appRoleAssignedTo` relationship of the _resource_ service principal, instead of the `appRoleAssignments` relationship of the assigned user, group, or service principal.
 
 ## Request headers
 

--- a/api-reference/v1.0/api/serviceprincipal-delete-approleassignments.md
+++ b/api-reference/v1.0/api/serviceprincipal-delete-approleassignments.md
@@ -9,7 +9,7 @@ author: "davidmu1"
 
 # Delete an appRoleAssignment granted to a service principal
 
-Deletes an [appRoleAssignment](../resources/approleassignment.md) which a service principal has been granted.
+Deletes an [appRoleAssignment](../resources/approleassignment.md) that a service principal has been granted.
 
 App roles which are assigned to service principals are also known as [application permissions](https://docs.microsoft.com/azure/active-directory/develop/v2-permissions-and-consent#permission-types). Deleting an app role assignment for a service principal is equivalent to revoking the app-only permission grant.
 
@@ -32,7 +32,7 @@ DELETE /servicePrincipals/{id}/appRoleAssignments/{id}
 ```
 
 > [!NOTE]
-> As a best practice, we recommend deleting app role assignments through the `appRoleAssignedTo` relationship of the _resource_ service principal, instead of the `appRoleAssignments` relationship of the assigned user, group or service principal.
+> As a best practice, we recommend deleting app role assignments through the `appRoleAssignedTo` relationship of the _resource_ service principal, instead of the `appRoleAssignments` relationship of the assigned user, group, or service principal.
 
 ## Request headers
 

--- a/api-reference/v1.0/api/serviceprincipal-list-approleassignedto.md
+++ b/api-reference/v1.0/api/serviceprincipal-list-approleassignedto.md
@@ -9,11 +9,11 @@ author: "davidmu1"
 
 # List appRoleAssignments granted for a service principal
 
-Retrieve a list of [appRoleAssignment](../resources/approleassignment.md) which users, groups or client service principals have been granted for the given resource service principal.
+Retrieve a list of [appRoleAssignment](../resources/approleassignment.md) that users, groups, or client service principals have been granted for the given resource service principal.
 
-For example, if the resource service principal is the service principal for the Microsoft Graph API, this will return all service principals which have been granted any app-only permissions to Microsoft Graph.
+For example, if the resource service principal is the service principal for the Microsoft Graph API, this will return all service principals that have been granted any app-only permissions to Microsoft Graph.
 
-If the resource service principal is an application which has app roles granted to users and groups, this will return all the users and groups assigned app roles for this application.
+If the resource service principal is an application that has app roles granted to users and groups, this will return all the users and groups assigned app roles for this application.
 
 ## Permissions
 
@@ -34,9 +34,9 @@ GET /servicePrincipals/{id}/appRoleAssignedTo
 
 ## Optional query parameters
 
-This method supports the [OData Query Parameters](https://developer.microsoft.com/graph/docs/concepts/query_parameters) to help customize the response.
+This method supports the [OData query parameters](/graph/query-parameters) to help customize the response.
 
-See [supported filter patterns](../resources/approleassignment.md#supported-filter-patterns) to learn how to search for and filter app role assignments.
+To learn how to search for and filter app role assignments, see [supported filter patterns](../resources/approleassignment.md#supported-filter-patterns).
 
 ## Request headers
 
@@ -50,13 +50,13 @@ Do not supply a request body for this method.
 
 ## Response
 
-If successful, this method returns a `200 OK` response code and collection of [appRoleAssignment](../resources/approleassignment.md) objects in the response body.
+If successful, this method returns a `200 OK` response code and a collection of [appRoleAssignment](../resources/approleassignment.md) objects in the response body.
 
 ## Example
 
 ### Request
 
-Here is an example of the request to retrieve the app roles assignments which have been granted for a given resource service principal.
+The following is an example of the request to retrieve the app roles assignments that have been granted for a given resource service principal.
 
 <!-- {
   "blockType": "request",
@@ -69,7 +69,9 @@ GET https://graph.microsoft.com/v1.0/servicePrincipals/{id}/appRoleAssignedTo
 
 ### Response
 
-Here is an example of the response. Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.
+Here is an example of the response. 
+
+> **Note:** The response object shown here might be shortened for readability. All the properties will be returned from an actual call.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/serviceprincipal-list-approleassignments.md
+++ b/api-reference/v1.0/api/serviceprincipal-list-approleassignments.md
@@ -9,9 +9,10 @@ author: "davidmu1"
 
 # List appRoleAssignments granted to a service principal
 
-Retrieve the list of [appRoleAssignment](../resources/approleassignment.md) which a service principal has been granted.
 
-App roles which are assigned to service principals are also known as [application permissions](https://docs.microsoft.com/azure/active-directory/develop/v2-permissions-and-consent#permission-types). Application permissions can be granted directly by creating app role assignments, or through a [consent experience](https://docs.microsoft.com/azure/active-directory/develop/application-consent-experience).
+Retrieve the list of [appRoleAssignment](../resources/approleassignment.md) that have been granted to a service principal.
+
+App roles that are assigned to service principals are also known as [application permissions](https://docs.microsoft.com/azure/active-directory/develop/v2-permissions-and-consent#permission-types). Application permissions can be granted directly by creating app role assignments, or through a [consent experience](https://docs.microsoft.com/azure/active-directory/develop/application-consent-experience).
 
 ## Permissions
 
@@ -32,9 +33,9 @@ GET /servicePrincipals/{id}/appRoleAssignments
 
 ## Optional query parameters
 
-This method supports the [OData Query Parameters](https://developer.microsoft.com/graph/docs/concepts/query_parameters) to help customize the response.
+This method supports the [OData query parameters](/graph/query-parameters) to help customize the response.
 
-See [supported filter patterns](../resources/approleassignment.md#supported-filter-patterns) to learn how to search for and filter app role assignments.
+To learn how to search for and filter app role assignments, see [supported filter patterns](../resources/approleassignment.md#supported-filter-patterns).
 
 ## Request headers
 
@@ -48,13 +49,13 @@ Do not supply a request body for this method.
 
 ## Response
 
-If successful, this method returns a `200 OK` response code and collection of [appRoleAssignment](../resources/approleassignment.md) objects in the response body.
+If successful, this method returns a `200 OK` response code and a collection of [appRoleAssignment](../resources/approleassignment.md) objects in the response body.
 
 ## Example
 
 ### Request
 
-Here is an example of the request to retrieve the app roles which have been assigned to a service principal.
+The following is an example of a request to retrieve the app roles that have been assigned to a service principal.
 
 <!-- {
   "blockType": "request",
@@ -67,7 +68,9 @@ GET https://graph.microsoft.com/v1.0/servicePrincipals/{id}/appRoleAssignments
 
 ### Response
 
-Here is an example of the response. Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.
+Here is an example of the response. 
+
+> **Note:** The response object shown here might be shortened for readability. All the properties will be returned from an actual call.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/serviceprincipal-list-oauth2permissiongrants.md
+++ b/api-reference/v1.0/api/serviceprincipal-list-oauth2permissiongrants.md
@@ -2,7 +2,7 @@
 title: "servicePrincipal: List delegated permission grants (oauth2PermissionGrants)"
 description: "Retrieve a list of oAuth2PermissionGrant objects, representing delegated permission grants."
 localization_priority: Priority
-doc_type: resourcePageType
+doc_type: apiPageType
 ms.prod: "microsoft-identity-platform"
 author: "davidmu1"
 ---
@@ -31,7 +31,7 @@ GET /servicePrincipals/{id}/oauth2PermissionGrants
 
 ## Optional query parameters
 
-This method supports the [OData Query Parameters](https://developer.microsoft.com/graph/docs/concepts/query_parameters) to help customize the response.
+This method supports the [OData query parameters](/graph/query_parameters) to help customize the response.
 
 ## Request headers
 
@@ -64,7 +64,9 @@ GET https://graph.microsoft.com/v1.0/servicePrincipals/{id}/oauth2PermissionGran
 
 ### Response
 
-Here is an example of the response. Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.
+Here is an example of the response. 
+
+> **Note:** The response object shown here might be shortened for readability. All the properties will be returned from an actual call.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/serviceprincipal-post-approleassignedto.md
+++ b/api-reference/v1.0/api/serviceprincipal-post-approleassignedto.md
@@ -9,15 +9,16 @@ author: "davidmu1"
 
 # Grant an appRoleAssignment for a service principal
 
-Use this API to assign an app role for a resource service principal, to a user, group or client service principal.
 
-App roles which are assigned to service principals are also known as [application permissions](https://docs.microsoft.com/azure/active-directory/develop/v2-permissions-and-consent#permission-types). Application permissions can be granted directly with app role assignments, or through a [consent experience](https://docs.microsoft.com/azure/active-directory/develop/application-consent-experience).
+Assign an app role for a resource service principal, to a user, group, or client service principal.
 
-To grant an app role assignment you need three identifiers:
+App roles that are assigned to service principals are also known as [application permissions](https://docs.microsoft.com/azure/active-directory/develop/v2-permissions-and-consent#permission-types). Application permissions can be granted directly with app role assignments, or through a [consent experience](https://docs.microsoft.com/azure/active-directory/develop/application-consent-experience).
 
-1. `principalId`: The `id` of the **user**, **group** or client **servicePrincipal** to which you are assigning the app role.
-2. `resourceId`: The `id` of the resource **servicePrincipal** which has defined the app role.
-3. `appRoleId`: The `id` of the **appRole** (defined on the resource service principal) to assign to a user, group or service principal.
+To grant an app role assignment, you need three identifiers:
+
+- `principalId`: The `id` of the **user**, **group** or client **servicePrincipal** to which you are assigning the app role.
+- `resourceId`: The `id` of the resource **servicePrincipal** which has defined the app role.
+- `appRoleId`: The `id` of the **appRole** (defined on the resource service principal) to assign to a user, group, or service principal.
 
 ## Permissions
 
@@ -45,11 +46,11 @@ POST /servicePrincipals/{id}/appRoleAssignedTo
 
 ## Request body
 
-In the request body, supply a JSON representation of [appRoleAssignment](../resources/approleassignment.md) object.
+In the request body, supply a JSON representation of an [appRoleAssignment](../resources/approleassignment.md) object.
 
 ## Response
 
-If successful, this method returns `201 Created` response code and [appRoleAssignment](../resources/approleassignment.md) object in the response body.
+If successful, this method returns a `201 Created` response code and an [appRoleAssignment](../resources/approleassignment.md) object in the response body.
 
 ## Examples
 
@@ -74,11 +75,13 @@ Content-Length: 110
 }
 ```
 
-In this example, `{id}` and `{resourceId-value}` would both be the `id` of the resource service principal, and `{principalId}` would be the `id` of the assigned user, group or client service principal.
+In this example, `{id}` and `{resourceId-value}` would both be the `id` of the resource service principal, and `{principalId}` would be the `id` of the assigned user, group, or client service principal.
 
 ### Response
 
-Here is an example of the response. Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.
+Here is an example of the response. 
+
+> **Note:** The response object shown here might be shortened for readability. All the properties will be returned from an actual call.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/serviceprincipal-post-approleassignments.md
+++ b/api-reference/v1.0/api/serviceprincipal-post-approleassignments.md
@@ -9,15 +9,16 @@ author: "davidmu1"
 
 # Grant an appRoleAssignment to a service principal
 
-Use this API to assign an app role to a client service principal.
 
-App roles which are assigned to service principals are also known as [application permissions](https://docs.microsoft.com/azure/active-directory/develop/v2-permissions-and-consent#permission-types). Application permissions can be granted directly with app role assignments, or through a [consent experience](https://docs.microsoft.com/azure/active-directory/develop/application-consent-experience).
+Assign an app role to a client service principal.
+
+App roles that are assigned to service principals are also known as [application permissions](https://docs.microsoft.com/azure/active-directory/develop/v2-permissions-and-consent#permission-types). Application permissions can be granted directly with app role assignments, or through a [consent experience](https://docs.microsoft.com/azure/active-directory/develop/application-consent-experience).
 
 To grant an app role assignment to a client service principal, you need three identifiers:
 
-1. `principalId`: The `id` of the client service principal to which you are assigning the app role.
-2. `resourceId`: The `id` of the resource `servicePrincipal` (the API) which has defined the app role (the application permission).
-3. `appRoleId`: The `id` of the `appRole` (defined on the resource service principal) to assign to the client service principal.
+- `principalId`: The `id` of the client service principal to which you are assigning the app role.
+- `resourceId`: The `id` of the resource `servicePrincipal` (the API) which has defined the app role (the application permission).
+- `appRoleId`: The `id` of the `appRole` (defined on the resource service principal) to assign to the client service principal.
 
 ## Permissions
 
@@ -37,7 +38,7 @@ POST /servicePrincipals/{id}/appRoleAssignments
 ```
 
 > [!NOTE]
-> As a best practice, we recommend creating app role assignments through the [`appRoleAssignedTo` relationship of the _resource_ service principal](serviceprincipal-post-approleassignedto.md), instead of the `appRoleAssignments` relationship of the assigned user, group or service principal.
+> As a best practice, we recommend creating app role assignments through the [`appRoleAssignedTo` relationship of the _resource_ service principal](serviceprincipal-post-approleassignedto.md), instead of the `appRoleAssignments` relationship of the assigned user, group, or service principal.
 
 ## Request headers
 
@@ -48,11 +49,11 @@ POST /servicePrincipals/{id}/appRoleAssignments
 
 ## Request body
 
-In the request body, supply a JSON representation of [appRoleAssignment](../resources/approleassignment.md) object.
+In the request body, supply a JSON representation of an [appRoleAssignment](../resources/approleassignment.md) object.
 
 ## Response
 
-If successful, this method returns `201 Created` response code and [appRoleAssignment](../resources/approleassignment.md) object in the response body.
+If successful, this method returns a `201 Created` response code and an [appRoleAssignment](../resources/approleassignment.md) object in the response body.
 
 ## Examples
 
@@ -81,7 +82,9 @@ In this example, `{id}` and `{principalId-value}` would both be the `id` of the 
 
 ### Response
 
-Here is an example of the response. Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.
+Here is an example of the response. 
+
+> **Note:** The response object shown here might be shortened for readability. All the properties will be returned from an actual call.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/user-delete-approleassignments.md
+++ b/api-reference/v1.0/api/user-delete-approleassignments.md
@@ -30,7 +30,7 @@ DELETE /users/{id}/appRoleAssignments/{id}
 ```
 
 > [!NOTE]
-> As a best practice, we recommend deleting app role assignments through the `appRoleAssignedTo` relationship of the _resource_ service principal, instead of the `appRoleAssignments` relationship of the assigned user, group or service principal.
+> As a best practice, we recommend deleting app role assignments through the `appRoleAssignedTo` relationship of the _resource_ service principal, instead of the `appRoleAssignments` relationship of the assigned user, group, or service principal.
 
 ## Request headers
 

--- a/api-reference/v1.0/api/user-list-approleassignments.md
+++ b/api-reference/v1.0/api/user-list-approleassignments.md
@@ -9,7 +9,8 @@ author: "davidmu1"
 
 # List appRoleAssignments granted to a user
 
-Retrieve the list of [appRoleAssignment](../resources/approleassignment.md) which a user has been granted. Also returns app roles assigned to groups which the user is a direct member of.
+
+Retrieve the list of [appRoleAssignment](../resources/approleassignment.md) that a user has been granted. Also returns app roles assigned to groups that the user is a direct member of.
 
 ## Permissions
 
@@ -30,7 +31,7 @@ GET /users/{id | userPrincipalName}/appRoleAssignments
 
 ## Optional query parameters
 
-This method supports the [OData Query Parameters](https://developer.microsoft.com/graph/docs/concepts/query_parameters) to help customize the response.
+This method supports the [OData query parameters](/graph/query_parameters) to help customize the response.
 
 See [supported filter patterns](../resources/approleassignment.md#supported-filter-patterns) to learn how to search for and filter app role assignments.
 
@@ -65,7 +66,9 @@ GET https://graph.microsoft.com/v1.0/users/{id}/appRoleAssignments
 
 ### Response
 
-Here is an example of the response. Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.
+Here is an example of the response. 
+
+> **Note:** The response object shown here might be shortened for readability. All the properties will be returned from an actual call.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/user-list-oauth2permissiongrants.md
+++ b/api-reference/v1.0/api/user-list-oauth2permissiongrants.md
@@ -2,7 +2,7 @@
 title: "user: List delegated permission grants (oauth2PermissionGrants)"
 description: "Retrieve a list of oAuth2PermissionGrant objects, representing delegated permission grants."
 localization_priority: Priority
-doc_type: resourcePageType
+doc_type: apiPageType
 ms.prod: "microsoft-identity-platform"
 author: "davidmu1"
 ---
@@ -35,7 +35,7 @@ GET /users/{id | userPrincipalName}/oauth2PermissionGrants
 
 ## Optional query parameters
 
-This method supports the [OData Query Parameters](https://developer.microsoft.com/graph/docs/concepts/query_parameters) to help customize the response.
+This method supports the [OData query parameters](/graph/query_parameters) to help customize the response.
 
 ## Request headers
 
@@ -68,7 +68,9 @@ GET https://graph.microsoft.com/v1.0/users/{id}/oauth2PermissionGrants
 
 ### Response
 
-Here is an example of the response. Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.
+Here is an example of the response. 
+
+> **Note:** The response object shown here might be shortened for readability. All the properties will be returned from an actual call.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/user-post-approleassignments.md
+++ b/api-reference/v1.0/api/user-post-approleassignments.md
@@ -33,7 +33,7 @@ POST /users/{id | userPrincipalName}/appRoleAssignments
 ```
 
 > [!NOTE]
-> As a best practice, we recommend creating app role assignments through the `appRoleAssignedTo` relationship of the _resource_ service principal, instead of the `appRoleAssignments` relationship of the assigned user, group or service principal.
+> As a best practice, we recommend creating app role assignments through the `appRoleAssignedTo` relationship of the _resource_ service principal, instead of the `appRoleAssignments` relationship of the assigned user, group, or service principal.
 
 ## Request headers
 
@@ -77,7 +77,9 @@ In this example, `{id}` and `{principalId-value}` would both be the `id` of the 
 
 ### Response
 
-Here is an example of the response. Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.
+Here is an example of the response. 
+
+> **Note:** The response object shown here might be shortened for readability. All the properties will be returned from an actual call.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/resources/approle.md
+++ b/api-reference/v1.0/resources/approle.md
@@ -9,14 +9,15 @@ author: "davidmu1"
 
 # appRole resource type
 
-Represents an application role that may be requested by a client application calling another application or that may be used to assign an application to users or groups in a specified application role. The **appRoles** property <!-- of the [servicePrincipal](serviceprincipal.md) entity and --> of the [application](application.md) entity is a collection of **appRole**.
+Represents an application role which may be requested by (and granted to) a client application, or which may be used to assign an application to users or groups in a specified role. 
 
 The **appRoles** property of the [application](application.md) and [servicePrincipal](serviceprincipal.md) entities are a collection of **appRole**. 
 
 With [appRoleAssignments](approleassignment.md), app roles can be assigned to users, groups, or other applications' service principals.
 
 ## Properties
-| Property	   | Type	|Description|
+
+| Property   | Type |Description|
 |:---------------|:--------|:----------|
 |allowedMemberTypes|String collection|Specifies whether this app role can be assigned to users and groups (by setting to `["User"]`), to other application's (by setting to `["Application"]`, or both (by setting to `["User", "Application"]`). App roles supporting assignment of other applications' service principals are also known as [application permissions](/graph/auth/auth-concepts#microsoft-graph-permissions).|
 |description|String|The description for the app role. This is displayed when the app role is being assigned and, if the app role functions as an application permission, during  consent experiences.|

--- a/api-reference/v1.0/resources/approleassignment.md
+++ b/api-reference/v1.0/resources/approleassignment.md
@@ -1,15 +1,16 @@
 ---
 title: "appRoleAssignment resource type"
-description: "Used to record when a user, group or service principal is assigned to an app role on an application's service principal. You can create, read and delete app role assignments."
+description: "Used to record when a user, group, or service principal is assigned to an app role on an application's service principal. You can create, read and delete app role assignments."
 localization_priority: Priority
 doc_type: resourcePageType
 ms.prod: "microsoft-identity-platform"
-author: "psignoret"
+author: "davidmu1"
 ---
 
 # appRoleAssignment resource type
 
-Used to record when a user, group or service principal is assigned an app role for an app.
+
+Used to record when a user, group, or service principal is assigned an app role for an app.
 
 An app role assignment is a relationship between the assigned principal (a user, a group, or a service principal), a resource application (the app's service principal) and an app role defined on the resource application.
 
@@ -27,7 +28,7 @@ An app role assignment where the assigned principal is a service principal is an
 | creationTimestamp | DateTimeOffset | The time when the app role assignment was created.The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: `'2014-01-01T00:00:00Z'`. Read-only. Does not support `$filter`. |
 | principalId | Guid | The unique identifier (**id**) for the [user](user.md), [group](group.md) or [service principal](serviceprincipal.md) being granted the app role. Required on create. Does not support `$filter` (see [note](#unsupported-filter-patterns)). |
 | principalType | String | The type of the assigned principal. This can either be "User", "Group" or "ServicePrincipal". Read-only. Does not support `$filter`. |
-| principalDisplayName | String |The display name of the user, group or service principal that was granted the app role assignment. Read-only. Supports `$filter` (`eq` and `startswith`). |
+| principalDisplayName | String |The display name of the user, group, or service principal that was granted the app role assignment. Read-only. Supports `$filter` (`eq` and `startswith`). |
 | resourceId | Guid |The unique identifier (**id**) for the resource [service principal](serviceprincipal.md) for which the assignment is made. Required on create. Supports `$filter` (`eq` only). |
 | resourceDisplayName | String | The display name of the resource app's service principal to which the assignment is made. Does not support `$filter`. |
 | appRoleId | Guid | The identifier (**id**) for the [app role](approle.md) which is assigned to the principal. This app role must be exposed in the **appRoles** property on the resource application's service principal (**resourceId**). If the resource application has not declared any app roles, a default app role ID of `00000000-0000-0000-0000-000000000000` can be specified to signal that the principal is assigned to the resource app without any specific app roles. Required on create. Does not support `$filter`. |
@@ -61,9 +62,9 @@ Here is a JSON representation of the resource
 
 Below are some common query patterns for app role assignments.
 
-### List the app role assignments a user, group or service principal has been granted for an app
+### List the app role assignments a user, group, or service principal has been granted for an app
 
-To find the app role assignments granted to a user, group or service principal (`{principal-id}`), for a given resource app (`{resource-id}`), query the `appRoleAssignments` navigation of the assigned principal and filter by `resourceId`.
+To find the app role assignments granted to a user, group, or service principal (`{principal-id}`), for a given resource app (`{resource-id}`), query the `appRoleAssignments` navigation of the assigned principal and filter by `resourceId`.
 
 ```http
 GET https://graph.microsoft.com/v1.0/users/{principal-id}/appRoleAssignments
@@ -82,7 +83,7 @@ GET https://graph.microsoft.com/v1.0/servicePrincipals/{principal-id}/appRoleAss
 
 ### Search for assigned principal by display name
 
-To find the app role assignments granted for an app (`{resource-id}`) and filter by the assigned users, groups and service principals' display name, query the `appRoleAssignedTo` navigation of the resource app's service principal and filter by `principalDisplayName`.
+To find the app role assignments granted for an app (`{resource-id}`) and filter by the assigned users, groups, and service principals' display name, query the `appRoleAssignedTo` navigation of the resource app's service principal and filter by `principalDisplayName`.
 
 ```http
 GET https://graph.microsoft.com/v1.0/servicePrincipals/{resource-id}/appRoleAssignedTo
@@ -98,7 +99,7 @@ GET https://graph.microsoft.com/v1.0/servicePrincipals/{resource-id}/appRoleAssi
 
 The following are some examples scenarios where service-side filtering is not currently supported, and client-side filtering may be required:
 
-* Filtering by `resourceDisplayName` for a given user, group or service principal is not supported. Instead, retrieve all app role assignments granted to assigned principal (with the `appRoleAssignments` navigation) and filter the results on the client side. Alternatively, filter all [**servicePrincipals**](../resources/serviceprincipal.md) to find the resource app's service principal `id`, and then filter the assigned principal's `appRoleAssignments` by `resourceId`. 
+* Filtering by `resourceDisplayName` for a given user, group, or service principal is not supported. Instead, retrieve all app role assignments granted to assigned principal (with the `appRoleAssignments` navigation) and filter the results on the client side. Alternatively, filter all [**servicePrincipals**](../resources/serviceprincipal.md) to find the resource app's service principal `id`, and then filter the assigned principal's `appRoleAssignments` by `resourceId`. 
 * Filtering by `appRoleId` is not supported. Instead, retrieve all app role assignments for the assigned principal and resource app (`appRoleAssignments` filtered by `resourceId`), or all app role assignments for the resource app (`appRoleAssignedTo`), and then further filter the results on the client side.
 * Filtering by `principalId` is not supported, but is usually not needed. Instead, query the assigned principal's app role assignments and filter by `resourceId`.
 

--- a/api-reference/v1.0/resources/serviceprincipal.md
+++ b/api-reference/v1.0/resources/serviceprincipal.md
@@ -26,9 +26,9 @@ Represents an instance of an application in a directory. Inherits from [director
 |[List appRoleAssignments](../api/serviceprincipal-list-approleassignments.md) |[appRoleAssignment](approleassignment.md) collection| Get the app roles which this service principal has been assigned.|
 |[Add appRoleAssignment](../api/serviceprincipal-post-approleassignments.md) |[appRoleAssignment](approleassignment.md)| Assign an app role to this service principal.|
 |[Remove appRoleAssignment](../api/serviceprincipal-delete-approleassignments.md) | None | Remove an app role assignment from this service principal.|
-|[List appRoleAssignedTo](../api/serviceprincipal-list-approleassignedto.md) |[appRoleAssignment](approleassignment.md) collection| Get the users, groups and service principals assigned app roles for this service principal.|
-|[Add appRoleAssignedTo](../api/serviceprincipal-post-approleassignedto.md) |[appRoleAssignment](approleassignment.md)| Assign an app role for this service principal to a user, group or service principal.|
-|[Remove appRoleAssignedTo](../api/serviceprincipal-delete-approleassignedto.md) | None | Remove an app role assignment for this service principal from a user, group or service principal.|
+|[List appRoleAssignedTo](../api/serviceprincipal-list-approleassignedto.md) |[appRoleAssignment](approleassignment.md) collection| Get the users, groups, and service principals assigned app roles for this service principal.|
+|[Add appRoleAssignedTo](../api/serviceprincipal-post-approleassignedto.md) |[appRoleAssignment](approleassignment.md)| Assign an app role for this service principal to a user, group, or service principal.|
+|[Remove appRoleAssignedTo](../api/serviceprincipal-delete-approleassignedto.md) | None | Remove an app role assignment for this service principal from a user, group, or service principal.|
 |**Certificates & secrets**| | |
 |[Add password](../api/serviceprincipal-addpassword.md)|[passwordCredential](passwordcredential.md)|Add a strong password to a servicePrincipal.|
 |[Remove password](../api/serviceprincipal-removepassword.md)|[passwordCredential](passwordcredential.md)|Remove a password from a servicePrincipal.|


### PR DESCRIPTION
* Used entity name instead of friendly name in titles for oAuth2PermissionGrant API docs.
* Updated to latest boilerplate text for truncated responses.
* Updated to serial commas everywhere.
* s/which/that
* Copied over changes in beta docs to v1.0.